### PR TITLE
A small fix in the task description.

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -4,7 +4,7 @@
 
 <p>
     Tic-Tac-Toe, sometimes also known as Xs and Os, is a game for two players
-    (X and O) who take turns marking the spaces in a 3×3 grid.
+    (X and O) who take turns marking the spaces in a 3x3 grid.
     The player who succeeds in placing three respective marks in a horizontal, vertical, or diagonal rows (NW-SE and
     NE-SW) wins the game.
 </p>


### PR DESCRIPTION
'3×3' at line 7 appeared as '3Ă3'. Fixed by replacing '×' with an 'x'.
